### PR TITLE
buffer support for browser

### DIFF
--- a/polyfills.ts
+++ b/polyfills.ts
@@ -87,3 +87,9 @@ import "@angular/localize/init";
 
 // required by exceljs (no longer used)
 // import "regenerator-runtime/runtime";
+
+/* To reference and create an instance of the Buffer. This requires to install the buffer package. */
+(window as any).global = window;
+declare var global: (any);
+declare var require: (any);
+global.Buffer = global.Buffer || require('buffer').Buffer;

--- a/src/package.json
+++ b/src/package.json
@@ -69,7 +69,8 @@
     "ajv-formats": "2.1.1",
     "angular-polyfills": "1.0.1",
     "localstorage-polyfill": "1.0.1",
-    "gzipper": "7.1.0"
+    "gzipper": "7.1.0",
+    "buffer": "6.0.3"
   },
   "devDependencies": {
     "karma": "6.4.0",


### PR DESCRIPTION
add buffer package as core dependency and edit polyfills in order to make the buffer globally accessable.
This fixes error: 'nodebuffer is not supported by this platform'.

This allows me to use shpjs lib for converting zip shape file into geojson. For example:

```
this.dataService.readFileContent(file)
      .toPromise().then(
        res => {
          shp(res).then((geojson) => {
            console.log(geojson);
          });
        }
      );
```