### PR TITLE
add the sticky-bottom class to the footer

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -37,7 +37,7 @@
 <!-- Used to create a separation between router-outlet and footer -->
 <div class="spacer"></div>
 
-<footer class="footer mt-auto" *ngIf="enableFooter">
+<footer class="footer mt-auto sticky-bottom" *ngIf="enableFooter">
   <customfooter></customfooter>
 </footer>
 


### PR DESCRIPTION
This class will ensure the same level stack of the header on top (z-index: 1020). For example, the spinner can use a z-index value to stay on top of the main content but lower than the navbar and the footer. z-index applied to inner custom div does not work. I see no problem using it in the footer as well.