### PR TITLE
fix toggle class for password input type

### DIFF
--- a/src/app/components/forms/password.type.ts
+++ b/src/app/components/forms/password.type.ts
@@ -22,11 +22,14 @@ import * as generator from "generate-password-browser";
         padding-right: 30px;
       }
       .toggle {
+        margin-right: 0;
+        margin-top: 0;
+        position: absolute;
         float: right;
-        margin-right: 10px;
-        margin-top: -27px;
-        position: relative;
-        z-index: 2;
+        right: -4px;
+        top: 10px;
+        padding: 0 0.75rem;
+        z-index: 6;
         color: gray;
       }
       .toggle-shift {
@@ -39,7 +42,7 @@ import * as generator from "generate-password-browser";
     <ng-template #fieldTypeTemplate>
       <input
         [type]="show ? 'text' : 'password'"
-        [formControl]="formControl"
+        [formControl]="formControl rounded-end"
         class="form-control"
         [formlyAttributes]="field"
         [class.is-invalid]="showError"


### PR DESCRIPTION
Fix style issue with password input (e.g. in the login page). With this fix the input field looks like the following

![image](https://github.com/rapydo/rapydo-angular/assets/11958518/1c7f6ffa-c7fe-4756-9316-c874599ebcf6)
