### PR TITLE
add the sticky-bottom class to the footer

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -37,7 +37,7 @@
 <!-- Used to create a separation between router-outlet and footer -->
 <div class="spacer"></div>
 
-<footer class="footer mt-auto" *ngIf="enableFooter">
+<footer class="footer mt-auto sticky-bottom" *ngIf="enableFooter">
   <customfooter></customfooter>
 </footer>
 

--- a/src/app/components/forms/password.type.ts
+++ b/src/app/components/forms/password.type.ts
@@ -22,11 +22,14 @@ import * as generator from "generate-password-browser";
         padding-right: 30px;
       }
       .toggle {
+        margin-right: 0;
+        margin-top: 0;
+        position: absolute;
         float: right;
-        margin-right: 10px;
-        margin-top: -27px;
-        position: relative;
-        z-index: 2;
+        right: -4px;
+        top: 10px;
+        padding: 0 0.75rem;
+        z-index: 6;
         color: gray;
       }
       .toggle-shift {
@@ -39,7 +42,7 @@ import * as generator from "generate-password-browser";
     <ng-template #fieldTypeTemplate>
       <input
         [type]="show ? 'text' : 'password'"
-        [formControl]="formControl"
+        [formControl]="formControl rounded-end"
         class="form-control"
         [formlyAttributes]="field"
         [class.is-invalid]="showError"

--- a/src/app/components/forms/password.type.ts
+++ b/src/app/components/forms/password.type.ts
@@ -42,8 +42,8 @@ import * as generator from "generate-password-browser";
     <ng-template #fieldTypeTemplate>
       <input
         [type]="show ? 'text' : 'password'"
-        [formControl]="formControl rounded-end"
-        class="form-control"
+        [formControl]="formControl"
+        class="form-control rounded-end"
         [formlyAttributes]="field"
         [class.is-invalid]="showError"
       />


### PR DESCRIPTION
This class will ensure the same level stack of the header on top (z-index: 1020). For example, the spinner can use a z-index value to stay on top of the main content but lower than the navbar and the footer. z-index applied to inner custom div does not work. I see no problem using it in the footer as well. (Duplicated of PR #342 because it was erroneously deleted)