### PR TITLE
allow to hide header and footer in 'iframe embedded' mode

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<navbar></navbar>
+<navbar #navbar></navbar>
 
 <div *ngIf="!api.is_online() && ssr.isBrowser">
   <div class="container-fluid">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from "@angular/core";
+import { Component, OnInit, ViewChild, AfterViewInit } from "@angular/core";
 import { ActivatedRoute, Router, NavigationEnd } from "@angular/router";
 import { Meta, Title } from "@angular/platform-browser";
 import { filter, map, mergeMap } from "rxjs/operators";
@@ -8,6 +8,7 @@ import { environment } from "@rapydo/../environments/environment";
 import { AuthService } from "@rapydo/services/auth";
 import { ApiService } from "@rapydo/services/api";
 import { SSRService } from "@rapydo/services/ssr";
+import { SharedService } from "@rapydo/services/shared-service";
 import { NavbarComponent } from "@rapydo/components/navbar/navbar";
 import { NotificationService } from "@rapydo/services/notification";
 import { ProjectOptions } from "@app/customization";
@@ -16,8 +17,9 @@ import { ProjectOptions } from "@app/customization";
   selector: "app-root",
   templateUrl: "app.component.html",
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, AfterViewInit {
   @ViewChild("cookieLaw", { static: false }) private cookieLawEl: any;
+  @ViewChild("navbar", {static: false}) private navbar: NavbarComponent;
 
   public cookieLawText: string;
   public cookieLawButton: string;
@@ -32,7 +34,8 @@ export class AppComponent implements OnInit {
     private notify: NotificationService,
     private route: ActivatedRoute,
     private router: Router,
-    public ssr: SSRService
+    public ssr: SSRService,
+    private sharedService: SharedService,
   ) {
     this.enableFooter = environment.enableFooter;
     this.cookieLawText = this.customization.cookie_law_text();
@@ -96,6 +99,17 @@ export class AppComponent implements OnInit {
           ]);
         }
       });
+  }
+
+  ngAfterViewInit(): void {
+    this.sharedService.iframeModeEmitted$.subscribe((isFlagOn: boolean) => {
+      setTimeout(() => {
+        // show/hide footer
+        this.enableFooter = !isFlagOn;
+      });
+      // show/hide navbar
+      isFlagOn ? this.navbar.hide() : this.navbar.show();
+    });
   }
 
   public dismissCookieLaw(): void {

--- a/src/app/components/navbar/navbar.ts
+++ b/src/app/components/navbar/navbar.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectorRef, OnInit } from "@angular/core";
+import { Component, ChangeDetectorRef, OnInit, Input, ElementRef, Renderer2 } from "@angular/core";
 import { Router } from "@angular/router";
 import { NgbModal, NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
 
@@ -30,6 +30,17 @@ export class NavbarComponent implements OnInit {
 
   public admin_entries: AdminMenu[];
 
+  @Input()
+  set display(value: string) {
+    this._display = value;
+    if (value === 'none') {
+      this.hide();
+      return;
+    }
+    this.show();
+  }
+  private _display = 'block';
+
   constructor(
     private router: Router,
     private modalService: NgbModal,
@@ -39,7 +50,9 @@ export class NavbarComponent implements OnInit {
     public ssr: SSRService,
     private auth: AuthService,
     private confirmationModals: ConfirmationModals,
-    private ref: ChangeDetectorRef
+    private ref: ChangeDetectorRef,
+    private _el: ElementRef,
+    private _renderer: Renderer2
   ) {
     this.showLogin = environment.showLogin;
     this.allowRegistration = environment.allowRegistration;
@@ -135,5 +148,15 @@ export class NavbarComponent implements OnInit {
       },
       (reason) => {}
     );
+  }
+
+  /** allows to manually show this content */
+  show(): void {
+    this._renderer.setStyle(this._el.nativeElement, 'display', this._display);
+  }
+
+  /** allows to manually hide content */
+  hide(): void {
+    this._renderer.setStyle(this._el.nativeElement, 'display', 'none');
   }
 }

--- a/src/app/rapydo.module.ts
+++ b/src/app/rapydo.module.ts
@@ -26,6 +26,7 @@ import { AuthService } from "@rapydo/services/auth";
 import { ApiService } from "@rapydo/services/api";
 import { FormlyService } from "@rapydo/services/formly";
 import { SSRService } from "@rapydo/services/ssr";
+import { SharedService } from "@rapydo/services/shared-service";
 import { NotificationService } from "@rapydo/services/notification";
 import { ExcelService } from "@rapydo/services/excel";
 import { ConfirmationModals } from "@rapydo/services/confirmation.modals";
@@ -144,6 +145,7 @@ let module_providers: any = [
   ApiService,
   FormlyService,
   SSRService,
+  SharedService,
   NotificationService,
   BaseProjectOptions,
   ConfirmationModals,

--- a/src/app/services/shared-service.ts
+++ b/src/app/services/shared-service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from "@angular/core";
+import { Observable, Subject } from "rxjs";
+
+@Injectable()
+export class SharedService {
+
+  private emitIframeSource = new Subject<boolean>();
+  iframeModeEmitted$ = this.emitIframeSource.asObservable();
+
+  /**
+   * Emit a change to enable embedded view in HTML iframe
+   */
+  emitChange(change: boolean) {
+    this.emitIframeSource.next(change);
+  }
+}


### PR DESCRIPTION
This PR arises from the need to allow the embedding of a web page in an external portal via iframe. 

The solution involves using a parameter in the request (eg iframe=true) which forwards the request to hide header and footer to the core component (via Subject rxjs).

For example the component for which we want to hide header and footer uses the new service to issue the change, like the following snippet:
```
this.route.queryParams.subscribe((params: Params) => {
  this.iframeMode = params["iframe"] || false;
  if (this.iframeMode) {
    this.sharedService.emitChange(true);
  }
});
```
The `app.component` subscribe to the `iframeModeEmitted$` observable and acts on both the header and footer.

