### PR TITLE
Disable the CookieLaw in iframe mode

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -41,7 +41,7 @@
   <customfooter></customfooter>
 </footer>
 
-<cookie-law #cookieLaw>
+<cookie-law #cookieLaw *ngIf="enableCookieLaw">
   <span
     *ngIf="cookieLawText; else defaultText"
     [innerHTML]="cookieLawText"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,6 +24,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   public cookieLawText: string;
   public cookieLawButton: string;
   public enableFooter: boolean = false;
+  public enableCookieLaw: boolean = true;
 
   constructor(
     public api: ApiService,
@@ -106,6 +107,10 @@ export class AppComponent implements OnInit, AfterViewInit {
       setTimeout(() => {
         // show/hide footer
         this.enableFooter = !isFlagOn;
+        // disable cookie-law in iframe mode
+        if (isFlagOn) {
+          this.enableCookieLaw = false;
+        }
       });
       // show/hide navbar
       isFlagOn ? this.navbar.hide() : this.navbar.show();


### PR DESCRIPTION
When iframe mode is activated, usually you don't want a "cookie law text" to pop up. So disable it!