### PR TITLE
Disable floating labels by default

### DIFF
--- a/src/app/services/formly.ts
+++ b/src/app/services/formly.ts
@@ -44,7 +44,7 @@ export class FormlyService {
 
       // Uhmm... show to handle with placeholders? Should I raise a warning!??
       // field["wrappers"] = ["form-field-floating"];
-      let floating_labels_supported = true;
+      let floating_labels_supported = false;
 
       if (stype === "string") {
         if (s.max && s.max > 256) {


### PR DESCRIPTION
Since version 2.4 of rapydo has been adopted in various production environments, we ask you to disable support for floating labels by default as it is currently not yet functional. We therefore ask you to postpone this fix to the next release (e.g. 3.0)