### PR TITLE
Add customcontrols to the top navbar

### DIFF
--- a/src/app/components/navbar/navbar.html
+++ b/src/app/components/navbar/navbar.html
@@ -77,6 +77,10 @@
 
       <!-- rpd-menu-controls is a hook to let custom styles from projects-->
       <ul class="nav navbar-nav ms-auto rpd-menu-controls" *ngIf="!loading">
+        <customcontrols
+           [user]="user"
+           (onClick)="isMenuCollapsed = true"
+        ></customcontrols>
         <li class="nav-item" *ngIf="user">
           <a
             class="nav-link"

--- a/src/app/rapydo.module.ts
+++ b/src/app/rapydo.module.ts
@@ -31,6 +31,7 @@ import { ConfirmationModals } from "@rapydo/services/confirmation.modals";
 import { JwtInterceptor } from "@rapydo/jwt.interceptor";
 
 import { CustomNavbarComponent } from "@app/custom.navbar";
+import { CustomControlsComponent } from "@app/custom.navbar";
 import { CustomBrandComponent } from "@app/custom.navbar";
 import { CustomFooterComponent } from "@app/custom.footer";
 import { BaseProjectOptions } from "@rapydo/base.project.options";
@@ -111,6 +112,7 @@ let module_declarations = [
   NavbarComponent,
 
   CustomNavbarComponent,
+  CustomControlsComponent,
   CustomBrandComponent,
   CustomFooterComponent,
 ];


### PR DESCRIPTION
`customcontrols` which acts like `customlinks` but extending the controls part. In particular in my case I would need to activate the language selection in a "multi-language" context.
This commit enables the custom code  with a new `custom.navbar.controls.html`. Eg a languae dropdown menu
```html
<li class="nav-item dropdown" ngbDropdown>
  <a class="nav-link" href="javascript:void(0)" ngbDropdownToggle>
    <i class="fa fa-language"></i>Language<b class="caret"></b>
  </a>
  <div class="dropdown-menu-right" ngbDropdownMenu>
    <a (click)="changeLang('en')" class="dropdown-item" href="javascript:void(0)">English</a>
    <a (click)="changeLang('it')" class="dropdown-item" href="javascript:void(0)">Italian</a>
  </div>
</li>
```
Need to extend `custom.navbar.ts` with:
```js
@Component({
  selector: "customcontrols",
  templateUrl: "custom.navbar.controls.html",
  changeDetection: ChangeDetectionStrategy.OnPush,
})
export class CustomControlsComponent {
  @Input() user: User;
  @Output() onClick: EventEmitter<null> = new EventEmitter<null>();
  constructor() {}
  public collapse() {
    this.onClick.emit();
  }
}
```
How to setup this code in the custom with `rapydo create`?